### PR TITLE
Improve testability and fix broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 sudo: false
 
 install:
-  - pip install -r requirements.txt
   - pip install -r requirements-dev.txt
 
 script:

--- a/acapi2/resources/acquiadata.py
+++ b/acapi2/resources/acquiadata.py
@@ -57,6 +57,8 @@ class AcquiaData(object):
             params = {k: v for k, v in params.items() if
                       v is not None}
             uri = self.generate_url_query(uri, params)
+        else:
+            params = {}
 
         response = None
         request = httphmac.Request()

--- a/acapi2/resources/application.py
+++ b/acapi2/resources/application.py
@@ -23,8 +23,8 @@ class Application(AcquiaResource):
             response = self.request(uri=uri, method="POST", data=data)
         except RequestException:
             print("There was an error in the request.")
-        else:
-            return response
+
+        return response
 
     def create_environment(self, label: str, env_name: str,
                            databases: list = None) -> Session:
@@ -47,8 +47,8 @@ class Application(AcquiaResource):
                                     method="POST", data=data)
         except RequestException:
             print("There was an error in the request.")
-        else:
-            return response
+
+        return response
 
     def environments(self,
                      filters: dict = None,

--- a/acapi2/resources/application.py
+++ b/acapi2/resources/application.py
@@ -7,7 +7,7 @@ from acapi2.resources.environment import Environment
 from acapi2.resources.environmentlist import EnvironmentList
 from acapi2.resources.tasklist import TaskList
 from requests.sessions import Session
-from requests.exceptions import HTTPError, RequestException
+from requests.exceptions import RequestException
 
 
 class Application(AcquiaResource):
@@ -39,7 +39,7 @@ class Application(AcquiaResource):
 
         uri = "{}/environments".format(self.uri)
 
-        #for db in databases:
+        # for db in databases:
         #    self.create_database(db)
 
         try:

--- a/acapi2/resources/applicationlist.py
+++ b/acapi2/resources/applicationlist.py
@@ -19,8 +19,8 @@ class ApplicationList(AcquiaList):
         self.fetch()
 
     def fetch(self) -> None:
-        apps = super().request(uri=self.uri,
-                               params=self._qry_params).json()
+        apps = self.request(uri=self.uri,
+                            params=self._qry_params).json()
         try:
             app_items = apps["_embedded"]["items"]
         except KeyError:

--- a/acapi2/resources/environment.py
+++ b/acapi2/resources/environment.py
@@ -5,7 +5,6 @@
 
 from acapi2.resources.acquiaresource import AcquiaResource
 from requests.sessions import Session
-from requests.exceptions import RequestException
 
 
 class Environment(AcquiaResource):
@@ -32,7 +31,6 @@ class Environment(AcquiaResource):
 
     def destroy(self):
         response = self.request(uri=self.uri, method="DELETE")
-        
         return response
 
     def deploy_code(self, id_from: str) -> Session:

--- a/acapi2/resources/environmentlist.py
+++ b/acapi2/resources/environmentlist.py
@@ -18,8 +18,8 @@ class EnvironmentList(AcquiaList):
         self.fetch()
 
     def fetch(self):
-        envs = super().request(uri=self.uri,
-                               params=self._qry_params).json()
+        envs = self.request(uri=self.uri,
+                            params=self._qry_params).json()
         try:
             env_items = envs["_embedded"]["items"]
         except KeyError:

--- a/acapi2/resources/subscriptionlist.py
+++ b/acapi2/resources/subscriptionlist.py
@@ -15,7 +15,7 @@ class SubscriptionList(AcquiaList):
         self.fetch()
 
     def fetch(self):
-        subs = super().request(uri=self.uri).json()
+        subs = self.request(uri=self.uri).json()
         try:
             sub_items = subs["_embedded"]["items"]
         except KeyError:

--- a/acapi2/resources/tasklist.py
+++ b/acapi2/resources/tasklist.py
@@ -18,8 +18,8 @@ class TaskList(AcquiaList):
         self.fetch()
 
     def fetch(self) -> None:
-        tasks = super().request(uri=self.uri,
-                                params=self._filters).json()
+        tasks = self.request(uri=self.uri,
+                             params=self._filters).json()
         try:
             task_items = tasks["_embedded"]["items"]
         except KeyError:

--- a/acapi2/tests/test_environments.py
+++ b/acapi2/tests/test_environments.py
@@ -13,7 +13,7 @@ class TestEnvironments(BaseTest):
     def test_destroy_env(self, mocker):
         app_uuid = "a47ac10b-58cc-4372-a567-0e02b2c3d470"
         env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
-        uri = "{base_uri}/applications/{uuid}/environments/{env_id}"
+        uri = "{base_uri}/applications/{uuid}/{env_id}"
         uri = uri.format(base_uri=self.endpoint, uuid=app_uuid,
                          env_id=env_id)
         response = {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 codecov==2.0.9
 flake8==3.5.0
 mypy==0.550


### PR DESCRIPTION
Mocking individual responses from AcquiaList subclasses is frustrating
when they use super() to call AcquiaData.request(). Switching to self
makes it easier to create a mock instance of the AcquiaList subclass
with the request() method overridden.