### PR TITLE
Fix version to match tagged release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='acapi2',
-    version='2.0.0-a1',
+    version='0.0.1-alpha1',
     url='https://github.com/pmatias/python-acquia-cloud-2',
     download_url='https://pypi.python.org/pypi/TBD',
     license='MIT',


### PR DESCRIPTION
The release was tagged as 0.0.1-alpha1 but the version in setup.py was
0.0.1-a1. This aligns the versions.