### PR TITLE
Bump requests-cache to 0.5.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 http-hmac-python==2.4.0
 requests>=2.20.0,<=2.23.0
-requests-cache==0.4.13
+requests-cache==0.5.2
 


### PR DESCRIPTION
It is a good idea to use the latest versions of dependencies so there is less effort when security releases are dropped by upstream. My other project that uses requests-cache depends 0.5.2, the slow update here is causing a version conflict.