### PR TITLE
Adding logs forwarding methods

### DIFF
--- a/acapi2/resources/environment.py
+++ b/acapi2/resources/environment.py
@@ -30,6 +30,26 @@ class Environment(AcquiaResource):
 
         return response
 
+    def create_log_forwarding_destinations(
+        self,
+        label: str,
+        sources: list,
+        consumer: str,
+        credentials: dict,
+        address: str
+    ) -> Session:
+        uri = self.uri + "/log-forwarding-destinations"
+        data = {
+            "label": label,
+            "sources": sources,
+            "consumer": consumer,
+            "credentials": credentials,
+            "address": address
+        }
+        response = self.request(uri=uri, method="POST", data=data)
+
+        return response
+
     def delete_domain(self, domain: str) -> Session:
         uri = self.uri + "/domains/{domain}".format(domain=domain)
         response = self.request(uri=uri, method="DELETE")
@@ -81,6 +101,12 @@ class Environment(AcquiaResource):
 
     def get_crons(self) -> dict:
         uri = self.uri + "/crons"
+
+        response = self.request(uri=uri)
+        return response.json()
+
+    def get_log_forwarding_destinations(self) -> dict:
+        uri = self.uri + "/log-forwarding-destinations"
 
         response = self.request(uri=uri)
         return response.json()

--- a/acapi2/tests/test_environments.py
+++ b/acapi2/tests/test_environments.py
@@ -70,6 +70,38 @@ class TestEnvironments(BaseTest):
         self.assertEqual(response.status_code, 202)
         self.assertIn(b"added", response.content)
 
+    def test_create_log_forwarding_destinations(self, mocker):
+        env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
+        uri = "{base_uri}/environments/{env_id}/log-forwarding-destinations"
+        uri = uri.format(base_uri=self.endpoint, env_id=env_id)
+
+        response_message = {
+            "message": "Log forwarding destination for the \
+            environment has been created."
+        }
+
+        mocker.register_uri("POST", uri,
+                            status_code=202, json=response_message)
+
+        label = "Test destination"
+        sources = [
+            "apache-access",
+            "apache-error"
+        ]
+        consumer = "syslog"
+        credentials = {
+            "certificate": "-----BEGIN CERTIFICATE-----...\
+            -----END CERTIFICATE-----"
+        }
+        address = "example.com:1234"
+
+        response = self.acquia.environment(
+                   env_id).create_log_forwarding_destinations(
+                   label, sources, consumer, credentials, address)
+
+        self.assertEqual(response.status_code, 202)
+        self.assertIn(b"created", response.content)
+
     def test_delete_domain(self, mocker):
         env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
         domain = "ceruleanhq.com"
@@ -172,6 +204,198 @@ class TestEnvironments(BaseTest):
 
         self.assertEqual(response.status_code, 202)
         self.assertIn(b"queued", response.content)
+
+    def test_get_crons(self, mocker):
+        env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
+        uri = "{base_uri}/environments/{env_id}/crons"
+        uri = uri.format(base_uri=self.endpoint, env_id=env_id)
+        response_message = {
+            "_embedded": {
+                "items": [
+                    {
+                        "_links": {
+                            "self": {
+                                "href": "{baseUri}/environments/24-a47ac10b-58cc-4372-a567-0e02b2c3d470\
+                                /crons/43595"
+                            }
+                        },
+                        "command": "/usr/local/bin/drush -r /var/www/html/mysub/docroot \
+                                   ah-db-backup mysub",
+                        "day_month": "*",
+                        "day_week": "*",
+                        "environment": {
+                            "id": "24-a47ac10b-58cc-4372-a567-0e02b2c3d470",
+                            "name": "prod"
+                        },
+                        "flags": {
+                            "enabled": True,
+                            "on_any_web": True,
+                            "system": True
+                        },
+                        "hour": "8",
+                        "id": "43595",
+                        "label": None,
+                        "minute": "0",
+                        "month": "*",
+                        "server": []
+                    },
+                    {
+                        "_links": {
+                            "self": {
+                                "href": "{baseUri}/environments/24-a47ac10b-58cc-4372-a567-0e02b2c3d470\
+                                /crons/56834"
+                            }
+                        },
+                        "command": "/usr/local/bin/drush9 --uri=[http://[site-uri] \
+                                --root=/var/www/html/${AH_SITE_NAME}/docroot \
+                                -dv cron &>> /var/log/sites/${AH_SITE_NAME}\
+                                /logs/$(hostname -s)/drush-cron.log",
+                        "day_month": "*",
+                        "day_week": "*",
+                        "environment": {
+                            "id": "24-a47ac10b-58cc-4372-a567-0e02b2c3d470",
+                            "name": "prod"
+                        },
+                        "flags": {
+                            "enabled": True,
+                            "on_any_web": True,
+                            "system": False
+                        },
+                        "hour": "*",
+                        "id": "56834",
+                        "label": "Site Cron Every Hour",
+                        "minute": "0",
+                        "month": "*",
+                        "server": []
+                    },
+                ]
+            },
+            "_links": {
+                "parent": {
+                    "href": "{baseUri}/environments/\
+                            24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
+                },
+                "self": {
+                    "href": "{baseUri}/environments/\
+                            24-a47ac10b-58cc-4372-a567-0e02b2c3d470/crons"
+                }
+            },
+            "total": 2
+        }
+
+        mocker.register_uri("GET", uri,
+                            status_code=200, json=response_message)
+
+        response = self.acquia.environment(env_id).get_crons()
+
+        self.assertEqual(response["total"], 2)
+        self.assertIn("_embedded", response)
+
+    def test_get_log_forwarding_destinations(self, mocker):
+        env_id = "5-185f07c7-9c4f-407b-8968-67892ebcb38a"
+        uri = "{base_uri}/environments/{env_id}/log-forwarding-destinations"
+        uri = uri.format(base_uri=self.endpoint, env_id=env_id)
+        response_message = {
+            "total": 2,
+            "_links": {
+                "self": {
+                    "href": "{base_uri}/environments/5-185f07c7-9c4f-407b-8968-67892ebcb38a\
+                    /log-forwarding-destinations"
+                },
+                "parent": {
+                    "href": "{base_uri}/environments\
+                    /5-185f07c7-9c4f-407b-8968-67892ebcb38a"
+                }
+            },
+            "_embedded": {
+                "items": [
+                    {
+                        "uuid": "df4c5428-8d2e-453d-9edf-e412647449b1",
+                        "label": "Test destination",
+                        "consumer": "sumologic",
+                        "address": "example.com:1234",
+                        "credentials": {
+                            "certificate": {
+                                "certificate": "-----BEGIN CERTIFICATE-----...\
+                                -----END CERTIFICATE-----",
+                                "expires_at": "2018-07-16T16:15:33+00:00"
+                            },
+                            "key": None,
+                            "token": "4ded264c8891c400df8fc8905f07beb5f"
+                        },
+                        "sources": [
+                            "apache-access",
+                            "apache-error"
+                        ],
+                        "status": "active",
+                        "flags": {
+                            "enabled": True,
+                            "certificate_expiring": False
+                        },
+                        "environment": {
+                            "id": "123-ea9060c5-1ed8-46ec-87d5-2ce2a0861577",
+                            "name": "Test"
+                        }
+                    },
+                    {
+                        "uuid": "df4c5428-8d2e-453d-9edf-e412647449b5",
+                        "label": "Another test destination",
+                        "consumer": "syslog",
+                        "address": "193.169.2.19:5678",
+                        "credentials": {
+                            "certificate": {
+                                "certificate": "-----BEGIN CERTIFICATE-----...\
+                                -----END CERTIFICATE-----",
+                                "expires_at": "2018-07-16T16:15:33+00:00"
+                            },
+                            "key": "1d0789d519c0b943cf38f401d30ffbdcd2",
+                            "token": "4ded264c8891c400df8fc8905f07beb5f"
+                        },
+                        "sources": [
+                            "drupal-request",
+                            "drupal-watchdog"
+                        ],
+                        "status": "active",
+                        "flags": {
+                            "enabled": False,
+                            "certificate_expiring": True
+                        },
+                        "environment": {
+                            "id": "123-ea9060c5-1ed8-46ec-87d5-2ce2a0861577",
+                            "name": "Test"
+                        }
+                    }
+                ]
+            }
+        }
+
+        mocker.register_uri("GET", uri,
+                            status_code=200, json=response_message)
+
+        response = self.acquia.environment(
+            env_id).get_log_forwarding_destinations()
+
+        self.assertEqual(response["total"], 2)
+        self.assertIn("_embedded", response)
+
+    def test_get_php_version(self, mocker):
+        env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
+        uri = "{base_uri}/environments/{env_id}/"
+        uri = uri.format(base_uri=self.endpoint, env_id=env_id)
+        response_message = {
+            'configuration': {
+                'php': {
+                    'version': '7.2'
+                }
+            }
+        }
+
+        mocker.register_uri("GET", uri,
+                            status_code=200, json=response_message)
+
+        response = self.acquia.environment(env_id).get_php_version()
+
+        self.assertEqual(response['php_version'], '7.2')
 
     def test_get_servers(self, mocker):
         env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
@@ -286,111 +510,6 @@ class TestEnvironments(BaseTest):
 
         self.assertEqual(response["total"], 2)
         self.assertIn("_embedded", response)
-
-    def test_get_crons(self, mocker):
-        env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
-        uri = "{base_uri}/environments/{env_id}/crons"
-        uri = uri.format(base_uri=self.endpoint, env_id=env_id)
-        response_message = {
-            "_embedded": {
-                "items": [
-                    {
-                        "_links": {
-                            "self": {
-                                "href": "{baseUri}/environments/24-a47ac10b-58cc-4372-a567-0e02b2c3d470\
-                                /crons/43595"
-                            }
-                        },
-                        "command": "/usr/local/bin/drush -r /var/www/html/mysub/docroot \
-                                   ah-db-backup mysub",
-                        "day_month": "*",
-                        "day_week": "*",
-                        "environment": {
-                            "id": "24-a47ac10b-58cc-4372-a567-0e02b2c3d470",
-                            "name": "prod"
-                        },
-                        "flags": {
-                            "enabled": True,
-                            "on_any_web": True,
-                            "system": True
-                        },
-                        "hour": "8",
-                        "id": "43595",
-                        "label": None,
-                        "minute": "0",
-                        "month": "*",
-                        "server": []
-                    },
-                    {
-                        "_links": {
-                            "self": {
-                                "href": "{baseUri}/environments/24-a47ac10b-58cc-4372-a567-0e02b2c3d470\
-                                /crons/56834"
-                            }
-                        },
-                        "command": "/usr/local/bin/drush9 --uri=[http://[site-uri] \
-                                --root=/var/www/html/${AH_SITE_NAME}/docroot \
-                                -dv cron &>> /var/log/sites/${AH_SITE_NAME}\
-                                /logs/$(hostname -s)/drush-cron.log",
-                        "day_month": "*",
-                        "day_week": "*",
-                        "environment": {
-                            "id": "24-a47ac10b-58cc-4372-a567-0e02b2c3d470",
-                            "name": "prod"
-                        },
-                        "flags": {
-                            "enabled": True,
-                            "on_any_web": True,
-                            "system": False
-                        },
-                        "hour": "*",
-                        "id": "56834",
-                        "label": "Site Cron Every Hour",
-                        "minute": "0",
-                        "month": "*",
-                        "server": []
-                    },
-                ]
-            },
-            "_links": {
-                "parent": {
-                    "href": "{baseUri}/environments/\
-                            24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
-                },
-                "self": {
-                    "href": "{baseUri}/environments/\
-                            24-a47ac10b-58cc-4372-a567-0e02b2c3d470/crons"
-                }
-            },
-            "total": 2
-        }
-
-        mocker.register_uri("GET", uri,
-                            status_code=200, json=response_message)
-
-        response = self.acquia.environment(env_id).get_crons()
-
-        self.assertEqual(response["total"], 2)
-        self.assertIn("_embedded", response)
-
-    def test_get_php_version(self, mocker):
-        env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
-        uri = "{base_uri}/environments/{env_id}/"
-        uri = uri.format(base_uri=self.endpoint, env_id=env_id)
-        response_message = {
-            'configuration': {
-                'php': {
-                    'version': '7.2'
-                }
-            }
-        }
-
-        mocker.register_uri("GET", uri,
-                            status_code=200, json=response_message)
-
-        response = self.acquia.environment(env_id).get_php_version()
-
-        self.assertEqual(response['php_version'], '7.2')
 
     def test_set_php_version(self, mocker):
         env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"


### PR DESCRIPTION
Added methods to list and create the logs forwarding destinations per environment:
- [create_log_forwarding_destinations()](https://cloudapi-docs.acquia.com/#/Environments/postEnvironmentsLogForwardingDestinations)
- [get_log_forwarding_destinations()](https://cloudapi-docs.acquia.com/#/Environments/getEnvironmentsLogForwardingDestinations)