### PR TITLE
Update and Delete logs forwarding

### DIFF
--- a/acapi2/resources/environment.py
+++ b/acapi2/resources/environment.py
@@ -119,6 +119,20 @@ class Environment(AcquiaResource):
 
         return response
 
+    def delete_log_forwarding_destinations(
+        self,
+        destination_uuid: str,
+    ) -> Session:
+        """
+        Delete a log forwarding destination.
+
+        :param destination_uuid: log forwarding destination uuid for given env.
+        """
+        uri = f"{self.uri}/log-forwarding-destinations/{destination_uuid}"
+        response = self.request(uri=uri, method="DELETE")
+
+        return response
+
     def clear_varnish_domain(self, domain: str) -> Session:
         """
         Clear the Varnish cache for the domain attached to this environment.

--- a/acapi2/resources/environment.py
+++ b/acapi2/resources/environment.py
@@ -82,6 +82,12 @@ class Environment(AcquiaResource):
     ) -> Session:
         """
         Create a log forwarding destination.
+        :param label: Human-friendly identifier of the destination
+        :param sources: List of log sources to forward
+        :param consumer: Application or provider consuming the logs.
+        :param credentials: Dictionary of certificate,key and token.
+        :param address: URL or host name and port of the destination.
+        :param destination_uuid: Log forwarding destination uuid for given env.
         """
         uri = f"{self.uri}/log-forwarding-destinations"
         data = {
@@ -243,3 +249,33 @@ class Environment(AcquiaResource):
         }
 
         return self.configure(data)
+
+    def update_log_forwarding_destinations(
+        self,
+        label: str,
+        sources: list,
+        consumer: str,
+        credentials: dict,
+        address: str,
+        destination_uuid: str,
+    ) -> Session:
+        """
+        Update a log forwarding destination.
+        :param label: Human-friendly identifier of the destination
+        :param sources: List of log sources to forward
+        :param consumer: Application or provider consuming the logs.
+        :param credentials: Dictionary of certificate,key and token.
+        :param address: URL or host name and port of the destination.
+        :param destination_uuid: Log forwarding destination uuid for given env.
+        """
+        uri = f"{self.uri}/log-forwarding-destinations/{destination_uuid}"
+        data = {
+            "label": label,
+            "sources": sources,
+            "consumer": consumer,
+            "credentials": credentials,
+            "address": address,
+        }
+        response = self.request(uri=uri, method="PUT", data=data)
+
+        return response

--- a/acapi2/tests/test_environments.py
+++ b/acapi2/tests/test_environments.py
@@ -464,6 +464,25 @@ class TestEnvironments(BaseTest):
 
         self.assertEqual(response.status_code, 202)
 
+    def test_delete_log_forwarding_destinations(self, mocker):
+        env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
+        destination_uuid = "df4c5428-8d2e-453d-9edf-e412647449b1"
+        uri = f"{self.endpoint}/environments/{env_id}/"\
+              f"log-forwarding-destinations/{destination_uuid}"
+
+        response_message = {
+            "message": "Log forwarding destination has been deleted."
+        }
+
+        mocker.register_uri("DELETE", uri,
+                            status_code=202, json=response_message)
+
+        response = self.acquia.environment(
+            env_id).delete_log_forwarding_destinations(destination_uuid)
+
+        self.assertEqual(response.status_code, 202)
+        self.assertIn(b"deleted", response.content)
+
     def test_destroy(self, mocker):
         env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
         uri = "{base_uri}/environments/{env_id}"

--- a/acapi2/tests/test_environments.py
+++ b/acapi2/tests/test_environments.py
@@ -855,3 +855,35 @@ class TestEnvironments(BaseTest):
 
         self.assertEqual(response.status_code, 202)
         self.assertIn(b"updated", response.content)
+
+    def test_update_log_forwarding_destinations(self, mocker):
+        env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"
+        destination_uuid = "df4c5428-8d2e-453d-9edf-e412647449b1"
+        uri = f"{self.endpoint}/environments/{env_id}/"\
+              f"log-forwarding-destinations/{destination_uuid}"
+
+        response_message = {
+            "message": "Log forwarding destination has been updated."
+        }
+
+        mocker.register_uri("PUT", uri,
+                            status_code=202, json=response_message)
+
+        label = "Test destination"
+        sources = [
+            "apache-access",
+            "apache-error"
+        ]
+        consumer = "syslog"
+        credentials = {
+            "certificate": "-----BEGIN CERTIFICATE-----...\
+            -----END CERTIFICATE-----"
+        }
+        address = "example.com:1234"
+
+        response = self.acquia.environment(
+            env_id).update_log_forwarding_destinations(
+            label, sources, consumer, credentials, address, destination_uuid)
+
+        self.assertEqual(response.status_code, 202)
+        self.assertIn(b"updated", response.content)


### PR DESCRIPTION
Added methods to update and delete the logs forwarding destinations per environment and destinations uuid:

- [update_log_forwarding_destinations](https://cloudapi-docs.acquia.com/#/Environments/putEnvironmentsLogForwardingDestination)
- [delete_log_forwarding_destinations](https://cloudapi-docs.acquia.com/#/Environments/deleteEnvironmentsDomain)