### PR TITLE
Wait for notification task is completed.

### DIFF
--- a/acapi2/exceptions.py
+++ b/acapi2/exceptions.py
@@ -12,17 +12,13 @@ class AcquiaCloudException(Exception):
     All acapi2 exceptions should extend this class.
     """
 
-    pass
-
 
 class AcquiaCloudNoDataException(AcquiaCloudException):
     """No data found exception."""
 
-    pass
 
-
-class AcquiaCloudTaskFailedException(AcquiaCloudException):
-    """An Acquia task failure exception."""
+class AcquiaCloudNotificationException(AcquiaCloudException):
+    """An Acquia notification exception."""
 
     def __init__(self, message, task):
         """Constructor.
@@ -34,7 +30,7 @@ class AcquiaCloudTaskFailedException(AcquiaCloudException):
         task: Task
             The Task object for the task that failed.
         """
-        super(AcquiaCloudTaskFailedException, self).__init__(message)
+        super().__init__(message)
         self.message = message
         self.task = task
 
@@ -50,6 +46,13 @@ class AcquiaCloudTaskFailedException(AcquiaCloudException):
         return f"{self.message}\n{task}"
 
 
-class AcquiaCloudPermissionException(AcquiaCloudException):
+class AcquiaCloudTaskFailedException(AcquiaCloudNotificationException):
+    """An Acquia task failure exception."""
 
-    pass
+
+class AcquiaCloudNotificationFailedException(AcquiaCloudNotificationException):
+    """An Acquia notification failure exception."""
+
+
+class AcquiaCloudTimeoutError(AcquiaCloudNotificationException):
+    """Timeout exceeded error."""

--- a/acapi2/resources/notification.py
+++ b/acapi2/resources/notification.py
@@ -5,7 +5,15 @@
 
 
 import logging
+import requests_cache
+import time
 
+from datetime import datetime, timedelta
+
+from acapi2.exceptions import (
+    AcquiaCloudNotificationFailedException,
+    AcquiaCloudTimeoutError
+)
 from acapi2.resources.acquiaresource import AcquiaResource
 
 
@@ -13,6 +21,7 @@ LOGGER = logging.getLogger('acapi2.resources.notification')
 
 
 class Notification(AcquiaResource):
+    POLL_INTERVAL = 3
 
     def __init__(self, uri: str,
                  api_key: str,
@@ -20,3 +29,46 @@ class Notification(AcquiaResource):
                  filters: dict = None,
                  *args, **kwargs) -> None:
         super().__init__(uri, api_key, api_secret, *args, **kwargs)
+
+    def pending(self) -> bool:
+        """Check if a notification is still pending.
+
+        :return: is the notification task in progress or no
+        """
+        with requests_cache.disabled():
+            notification = self.request().json()
+        self.data = notification
+        return notification["status"] == "in-progress"
+
+    def wait(self, timeout: int = 1800) -> "Notification":
+        """Wait for a notification task to finish executing.
+
+        :param timeout: the max number of seconds to wait for the notification
+                        to complete
+        :return: Notification object or raise exceptions
+        """
+        start = datetime.now()
+        max_time = start + timedelta(seconds=timeout)
+        while self.pending():
+            # Ensure the timeout hasn't been exceeded.
+            if datetime.now() >= max_time:
+                msg = f"Time out of exceeded while waiting " \
+                      f"for {self.data['uuid']}"
+                raise AcquiaCloudTimeoutError(msg, self.data)
+            time.sleep(self.POLL_INTERVAL)
+
+        # Grab the cached response
+        notification = self.data
+        if notification["status"] in ["failed", "error"]:
+            raise AcquiaCloudNotificationFailedException(
+                f"Notification {notification['uuid']} failed", notification
+            )
+
+        end = datetime.now()
+        delta = end - start
+        LOGGER.info(
+            "Waited %.2f seconds for notification to complete",
+            delta.total_seconds()
+        )
+
+        return self

--- a/acapi2/tests/fixtures/notification.json
+++ b/acapi2/tests/fixtures/notification.json
@@ -1,0 +1,29 @@
+{
+  "uuid": "1bd3487e-71d1-4fca-a2d9-5f969b3d35c1",
+  "event": "ApplicationAddedToRecents",
+  "label": "Application added to recents list",
+  "description": "\"Canary QA 11 - ACE\" was added to your recent applications list.",
+  "created_at": "2019-07-29T20:47:13+00:00",
+  "completed_at": "2019-07-29T20:47:13+00:00",
+  "status": "in-progress",
+  "progress": 0,
+  "context": {
+    "author": {
+      "uuid": "5391a8a9-d273-4f88-8114-7f884bbfe08b",
+      "actual_uuid": "5391a8a9-d273-4f88-8114-7f884bbfe08b"
+    },
+    "user": {
+      "uuids": [
+        "5391a8a9-d273-4f88-8114-7f884bbfe08b"
+      ]
+    }
+  },
+  "_links": {
+    "self": {
+      "href": "https://cloud.acquia.com/api/notifications/1bd3487e-71d1-4fca-a2d9-5f969b3d35c1"
+    },
+    "parent": {
+      "href": "https://cloud.acquia.com/api/notifications"
+    }
+  }
+}

--- a/acapi2/tests/fixtures/notification_completed.json
+++ b/acapi2/tests/fixtures/notification_completed.json
@@ -1,0 +1,29 @@
+{
+  "uuid": "1bd3487e-71d1-4fca-a2d9-5f969b3d35c1",
+  "event": "ApplicationAddedToRecents",
+  "label": "Application added to recents list",
+  "description": "\"Canary QA 11 - ACE\" was added to your recent applications list.",
+  "created_at": "2019-07-29T20:47:13+00:00",
+  "completed_at": "2019-07-29T20:47:13+00:00",
+  "status": "completed",
+  "progress": 100,
+  "context": {
+    "author": {
+      "uuid": "5391a8a9-d273-4f88-8114-7f884bbfe08b",
+      "actual_uuid": "5391a8a9-d273-4f88-8114-7f884bbfe08b"
+    },
+    "user": {
+      "uuids": [
+        "5391a8a9-d273-4f88-8114-7f884bbfe08b"
+      ]
+    }
+  },
+  "_links": {
+    "self": {
+      "href": "https://cloud.acquia.com/api/notifications/1bd3487e-71d1-4fca-a2d9-5f969b3d35c1"
+    },
+    "parent": {
+      "href": "https://cloud.acquia.com/api/notifications"
+    }
+  }
+}

--- a/acapi2/tests/fixtures/notification_failed.json
+++ b/acapi2/tests/fixtures/notification_failed.json
@@ -1,0 +1,29 @@
+{
+  "uuid": "1bd3487e-71d1-4fca-a2d9-5f969b3d35c1",
+  "event": "ApplicationAddedToRecents",
+  "label": "Application added to recents list",
+  "description": "\"Canary QA 11 - ACE\" was added to your recent applications list.",
+  "created_at": "2019-07-29T20:47:13+00:00",
+  "completed_at": "2019-07-29T20:47:13+00:00",
+  "status": "failed",
+  "progress": 100,
+  "context": {
+    "author": {
+      "uuid": "5391a8a9-d273-4f88-8114-7f884bbfe08b",
+      "actual_uuid": "5391a8a9-d273-4f88-8114-7f884bbfe08b"
+    },
+    "user": {
+      "uuids": [
+        "5391a8a9-d273-4f88-8114-7f884bbfe08b"
+      ]
+    }
+  },
+  "_links": {
+    "self": {
+      "href": "https://cloud.acquia.com/api/notifications/1bd3487e-71d1-4fca-a2d9-5f969b3d35c1"
+    },
+    "parent": {
+      "href": "https://cloud.acquia.com/api/notifications"
+    }
+  }
+}

--- a/acapi2/tests/test_notification.py
+++ b/acapi2/tests/test_notification.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""Test Notification Endpoint"""
+
+import requests_mock
+
+from unittest.mock import patch
+
+from acapi2.exceptions import (
+    AcquiaCloudNotificationFailedException,
+    AcquiaCloudTimeoutError
+)
+from acapi2.resources.notification import Notification
+from acapi2.tests import BaseTest
+from acapi2.tests.util import load_fixture
+
+
+@requests_mock.Mocker()
+class TestNotification(BaseTest):
+
+    def test_pending(self, mocker):
+        response = load_fixture("acapi2/tests/fixtures/notification.json")
+
+        notification_uuid = "1bd3487e-71d1-4fca-a2d9-5f969b3d35c1"
+        uri = f"{self.endpoint}/notifications/{notification_uuid}"
+        mocker.register_uri("GET", uri, status_code=200, json=response)
+        is_pending = self.acquia.notification(notification_uuid).pending()
+        assert is_pending
+
+    @patch.object(Notification, "pending", return_value=True)
+    def test_wait_in_progress(self, mocker, mock_pending):
+        response = load_fixture("acapi2/tests/fixtures/notification.json")
+
+        notification_uuid = "1bd3487e-71d1-4fca-a2d9-5f969b3d35c1"
+        uri = f"{self.endpoint}/notifications/{notification_uuid}"
+        mocker.register_uri("GET", uri, status_code=200, json=response)
+        with self.assertRaises(AcquiaCloudTimeoutError):
+            self.acquia.notification(notification_uuid).wait(5)
+
+    @patch.object(Notification, "pending", return_value=False)
+    def test_wait_failed(self, mocker, mock_pending):
+        response = load_fixture(
+            "acapi2/tests/fixtures/notification_failed.json"
+        )
+
+        notification_uuid = "1bd3487e-71d1-4fca-a2d9-5f969b3d35c1"
+        uri = f"{self.endpoint}/notifications/{notification_uuid}"
+        mocker.register_uri("GET", uri, status_code=200, json=response)
+        with self.assertRaises(AcquiaCloudNotificationFailedException):
+            self.acquia.notification(notification_uuid).wait(5)
+
+    @patch.object(Notification, "pending", return_value=False)
+    def test_wait_completed(self, mocker, mock_pending):
+        response = load_fixture(
+            "acapi2/tests/fixtures/notification_completed.json"
+        )
+
+        notification_uuid = "1bd3487e-71d1-4fca-a2d9-5f969b3d35c1"
+        uri = f"{self.endpoint}/notifications/{notification_uuid}"
+        mocker.register_uri("GET", uri, status_code=200, json=response)
+        notification = self.acquia.notification(notification_uuid).wait(5)
+        self.assertIsInstance(notification, Notification)

--- a/acapi2/tests/util.py
+++ b/acapi2/tests/util.py
@@ -1,0 +1,14 @@
+import json
+
+from typing import Dict
+
+
+def load_fixture(path: str) -> Dict:
+    """Load fixture from a json-file.
+
+    :param path: path to the file
+    :return: formatted dict
+    """
+    with open(path) as f:
+        result = f.read()
+    return json.loads(result)


### PR DESCRIPTION
Description: 
Changes let you wait and check if task which was run under the notification is completed or pending.
There is such functionality in `Task` class here. But it needs to be in `Notification` class coz "tasks" are kinda outdated. But I haven't removed it from `Task` class so code that is using it won't be broken.

Example of usage:
```
client = AcquiaClient()
notification = client.notification(notification_id).wait(30)
```