### PR TITLE
Backup download support.

### DIFF
--- a/acapi2/resources/environment.py
+++ b/acapi2/resources/environment.py
@@ -27,6 +27,18 @@ class Environment(AcquiaResource):
         uri = f"{self.uri}/databases/{db_name}/backups/{backup_id}"
         return self.request(uri=uri, method="GET").json()
 
+    def backup_download(self, db_name: str, backup_id: str) -> Session:
+        """
+        Get link to be able to download backup.
+
+        :param db_name: Database name, typically lower snake case.
+        :param backup_id: Database backup id.
+        :return: Acquia response
+        """
+        uri = f"{self.uri}/databases/{db_name}/backups/{backup_id}/" \
+            f"actions/download"
+        return self.request(uri=uri, method="GET").json()
+
     def code_switch(self, branch_tag: str) -> Session:
         """
         Switch code on this environment to a different branch or release tag.

--- a/acapi2/tests/test_environments.py
+++ b/acapi2/tests/test_environments.py
@@ -217,7 +217,7 @@ class TestEnvironments(BaseTest):
         self.assertEqual(response["total"], 2)
         self.assertIn("_embedded", response)
 
-    def backup_details(self, mocker):
+    def test_backup_details(self, mocker):
         env_id = "1-a47ac10b-58cc-4372-a567-0e02b2c3d470"
         db_name = "db_name"
         id_backup = "1"
@@ -287,8 +287,39 @@ class TestEnvironments(BaseTest):
 
         response = self.acquia.environment(env_id).backup_details(db_name,
                                                                   id_backup)
-        self.assertEqual(response["id"], "1")
+        self.assertEqual(response["id"], 1)
         self.assertIn("_embedded", response)
+
+    def test_backup_download(self, mocker):
+        env_id = "1-a47ac10b-58cc-4372-a567-0e02b2c3d470"
+        db_name = "db_name"
+        id_backup = "1"
+        uri = f"{self.endpoint}/environments/{env_id}/" \
+              f"databases/{db_name}/backups/{id_backup}/actions/download"
+
+        response = {
+            "url": "http://test-site.com/AH_DOWNLOAD?t=1&d=/mnt/files/site/"
+                   "backups/on-demand/backup.sql.gz&dev=hash",
+            "expires_at": "2020-03-27T10:26:51+00:00",
+            "_links": {
+                "self": {
+                    "href": "https://cloud.acquia.com/api/environments/"
+                            "1-a47ac10b-58cc-4372-a567-0e02b2c3d470/databases/"
+                            "db_name/backups/1/actions/download"
+                },
+                "parent": {
+                    "href": "https://cloud.acquia.com/api/environments/"
+                            "1-a47ac10b-58cc-4372-a567-0e02b2c3d470/databases/"
+                            "db_name/backups/1/actions"
+                }
+            }
+        }
+        mocker.register_uri("GET", uri, status_code=200, json=response)
+
+        response = self.acquia.environment(
+            env_id
+        ).backup_download(db_name, id_backup)
+        self.assertIn("url", response)
 
     def test_code_switch(self, mocker):
         env_id = "24-a47ac10b-58cc-4372-a567-0e02b2c3d470"


### PR DESCRIPTION
Description:
There is endpoint that returns the url of the backup in Acquia API V2:
https://cloudapi-docs.acquia.com/#/Environments/getEnvironmentsDatabaseDownloadBackup
So user is able to get this url and download backup file.

Example of usage:
```
client = AcquiaClient()
backup_url = client.environment(environment_id).backup_download(db_name, backup_id)
```
