### PR TITLE
Issue #32: Add support for SSL certificate management.

### DIFF
--- a/acapi2/resources/environment.py
+++ b/acapi2/resources/environment.py
@@ -353,7 +353,7 @@ class Environment(AcquiaResource):
         uri = f"{self.uri}/ssl"
         response = self.request(uri=uri)
 
-        return response.json().get('_embedded', {}).get('items')
+        return response.json()
 
     def get_ssl_certs(self) -> dict:
         """
@@ -362,7 +362,7 @@ class Environment(AcquiaResource):
         uri = f"{self.uri}/ssl/certificates"
         response = self.request(uri=uri)
 
-        return response.json()
+        return response.json().get('_embedded', {}).get('items')
 
     def get_ssl_cert(self, cert_id) -> dict:
         """

--- a/acapi2/resources/environment.py
+++ b/acapi2/resources/environment.py
@@ -351,9 +351,9 @@ class Environment(AcquiaResource):
         Return the SSL settings for the environment.
         """
         uri = f"{self.uri}/ssl"
-
         response = self.request(uri=uri)
-        return response.json()
+
+        return response.json().get('_embedded', {}).get('items')
 
     def get_ssl_certs(self) -> dict:
         """
@@ -426,7 +426,7 @@ class Environment(AcquiaResource):
         :param: cert_id: The Acquia certificate ID.
         """
         uri = f"{self.uri}/ssl/certificates/{cert_id}/actions/activate"
-        response = self.request(uri=uri, method="POST")
+        response = self.request(uri=uri, method="POST", data={})
 
         return response
 
@@ -436,6 +436,6 @@ class Environment(AcquiaResource):
         :param: cert_id: The Acquia certificate ID.
         """
         uri = f"{self.uri}/ssl/certificates/{cert_id}/actions/deactivate"
-        response = self.request(uri=uri, method="POST")
+        response = self.request(uri=uri, method="POST", data={})
 
         return response

--- a/acapi2/resources/environment.py
+++ b/acapi2/resources/environment.py
@@ -364,7 +364,7 @@ class Environment(AcquiaResource):
 
         return response.json().get('_embedded', {}).get('items')
 
-    def get_ssl_cert(self, cert_id) -> dict:
+    def get_ssl_cert(self, cert_id: str) -> dict:
         """
         Return an SSL cert.
         """
@@ -410,7 +410,7 @@ class Environment(AcquiaResource):
 
         return response
 
-    def delete_ssl_cert(self, cert_id) -> Session:
+    def delete_ssl_cert(self, cert_id: str) -> Session:
         """
         Remove an SSL cert.
         :param: cert_id: The Acquia certificate ID.
@@ -420,7 +420,7 @@ class Environment(AcquiaResource):
 
         return response
 
-    def activate_ssl_cert(self, cert_id) -> Session:
+    def activate_ssl_cert(self, cert_id: str) -> Session:
         """
         Activate a previously installed SSL cert.
         :param: cert_id: The Acquia certificate ID.
@@ -430,7 +430,7 @@ class Environment(AcquiaResource):
 
         return response
 
-    def deactivate_ssl_cert(self, cert_id) -> Session:
+    def deactivate_ssl_cert(self, cert_id: str) -> Session:
         """
         Deactivate a previously installed SSL cert.
         :param: cert_id: The Acquia certificate ID.

--- a/acapi2/resources/environment.py
+++ b/acapi2/resources/environment.py
@@ -345,3 +345,97 @@ class Environment(AcquiaResource):
         response = self.request(uri=uri, method="POST", data="")
 
         return response
+
+    def get_ssl_settings(self) -> dict:
+        """
+        Return the SSL settings for the environment.
+        """
+        uri = f"{self.uri}/ssl"
+
+        response = self.request(uri=uri)
+        return response.json()
+
+    def get_ssl_certs(self) -> dict:
+        """
+        Return a list of SSL certificates.
+        """
+        uri = f"{self.uri}/ssl/certificates"
+        response = self.request(uri=uri)
+
+        return response.json()
+
+    def get_ssl_cert(self, cert_id) -> dict:
+        """
+        Return an SSL cert.
+        """
+        uri = f"{self.uri}/ssl/certificates/{cert_id}"
+        response = self.request(uri=uri)
+
+        return response.json()
+
+    def install_ssl_cert(
+        self,
+        label: str,
+        certificate: str,
+        private_key: str,
+        ca_certificates: str = None,
+        legacy: bool = False,
+        csr_id: int = None,
+    ) -> Session:
+        """
+        Add a new SSL cert to the environment.
+        :param: label: Human-friendly identifier for the cert.
+        :param: certificate: The certificate in PEM format.
+        :param: private_key: The private keyfor the cert in PEM format.
+        :param: ca_certificates: Any chain certificates, in PEM format.
+         Defaults to None.
+        :param: legacy: Legacy in the sense of Acquia's legacy architecture,
+         not an old version of the SSL or TLS standards. See Acquia's docs
+         for more details. Defaults to False.
+        :param: csr_id: Associate with an existing installed CSR. Defaults
+         to None.
+        """
+        uri = f"{self.uri}/ssl/certificates"
+        data = {
+            "legacy": legacy,
+            "label": label,
+            "certificate": certificate,
+            "private_key": private_key,
+        }
+        if csr_id is not None:
+            data['csr_id'] = csr_id
+        if ca_certificates is not None:
+            data['ca_certificates'] = ca_certificates
+        response = self.request(uri=uri, method="POST", data=data)
+
+        return response
+
+    def delete_ssl_cert(self, cert_id) -> Session:
+        """
+        Remove an SSL cert.
+        :param: cert_id: The Acquia certificate ID.
+        """
+        uri = f"{self.uri}/ssl/certificates/{cert_id}"
+        response = self.request(uri=uri, method="DELETE")
+
+        return response
+
+    def activate_ssl_cert(self, cert_id) -> Session:
+        """
+        Activate a previously installed SSL cert.
+        :param: cert_id: The Acquia certificate ID.
+        """
+        uri = f"{self.uri}/ssl/certificates/{cert_id}/actions/activate"
+        response = self.request(uri=uri, method="POST")
+
+        return response
+
+    def deactivate_ssl_cert(self, cert_id) -> Session:
+        """
+        Deactivate a previously installed SSL cert.
+        :param: cert_id: The Acquia certificate ID.
+        """
+        uri = f"{self.uri}/ssl/certificates/{cert_id}/actions/deactivate"
+        response = self.request(uri=uri, method="POST")
+
+        return response


### PR DESCRIPTION
Add support for the following endpoints:

* `get_ssl_settings()`: /environments/{environment_uuid}/ssl
* `get_ssl_certs()`: /environments/{environment_uuid}/ssl/certificates
* `get_ssl_cert()`: /environments/{environment_uuid}/ssl/certificates/{cert_id}
* `install_ssl_cert()`: /environments/{environment_uuid}/ssl/certificates (POST)
* `delete_ssl_cert()`: /environments/{environment_uuid}/ssl/certificates/{cert_id} (DELETE)
* `activate_ssl_cert()`: /environments/{environment_uuid}/ssl/certificates/{cert_id}/actions/activate (POST)
* `deactivate_ssl_cert()`: /environments/{environment_uuid}/ssl/certificates/{cert_id}/actions/deactivate (POST)