### PR TITLE
Use loose dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-backoff==1.10.0
-http-hmac-python==2.4.1
-requests>=2.20.0,<=2.23.0
-requests-cache>=0.5.2,<=0.5.9
+.

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ setup(
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=[
-        'backoff==1.10.0',
-        'http-hmac-python>=2.4.0',
-        'requests>=2.20.0',
-        'requests-cache>=0.5.2',
-        'setuptools>=38.5'
+        'backoff>=1.10.0,<2'
+        'http-hmac-python>=2.4.1,<3',
+        'requests>=2.20.0,<=2.23.0',
+        'requests-cache>=0.5.2,<=0.5.9',
+        'setuptools>=38.5',
     ]
 )


### PR DESCRIPTION
Libraries should use loose dependencies to avoid conflicts with other projects. The old version of backoff is breaking dependabot updates in my projects.